### PR TITLE
Fix unification errors

### DIFF
--- a/accuracy_proofs/gemv_acc.v
+++ b/accuracy_proofs/gemv_acc.v
@@ -333,7 +333,7 @@ apply ler_pmul => //.
 apply normM_pos.
 apply normv_pos.
 rewrite /normM mulrC big_max_mul.
-apply le_bigmax2 => i0 _. 
+apply: le_bigmax2 => i0 _.
 rewrite /sum_abs.
 rewrite big_mul =>  [ | i b | ]; try ring.
 apply ler_sum => i _.
@@ -349,4 +349,4 @@ rewrite Hlenv1 in H2.
 apply H2.
 Qed.
 
-End ForwardError. 
+End ForwardError.

--- a/accuracy_proofs/mv_mathcomp.v
+++ b/accuracy_proofs/mv_mathcomp.v
@@ -614,7 +614,7 @@ Lemma subMultNorm m (A: 'M[R]_m.+1)  (u : 'cV_m.+1) :
 Proof.
 remember (normv u) as umax.
 rewrite /normr /normM /normv /sum_abs /= big_max_mul.
-apply le_bigmax2 => i0 _. 
+apply: le_bigmax2 => i0 _.
 rewrite mxE => /=.
 eapply le_trans.
 apply Rabs_sum .


### PR DESCRIPTION
I need these changes for LAProof to build on my configuration.  Not sure which particular version of which dependency needs this (Coq 8.18?)

Conflicts with #8, but I can rebase / recreate as necessary