### PR TITLE
Generalize verified CBLAS routines to signed strides

### DIFF
--- a/C/cblas/README.md
+++ b/C/cblas/README.md
@@ -49,10 +49,10 @@ theorem's own hypotheses, the bound holds of the C return value. In many cases (
 dot products and other reduction loops verified here) the one hypothesis the funspec does
 not already supply is a *no-overflow* condition: that the accumulated result is finite.
 
-For `cblas_ddot` that leftover precondition is exactly `Hfin`: that the accumulated result
-`dotprodF X Y` is finite. Requiring finite inputs would not establish it anyway, since a
-sum of finite products can still round to an infinity. The corresponding condition for
-`cblas_dasum` is that `sumF (map BABS X)` is finite.
+For `cblas_ddot` that leftover precondition is exactly `Hfin`: the `dotprodF` result over
+the two logical strided vectors must be finite. Requiring finite inputs would not establish
+it anyway, since a sum of finite products can still round to an infinity. The corresponding
+condition for `cblas_dasum` is that `sumF (map BABS (strided incX N X))` is finite.
 
 The `feq` postcondition cooperates here: the funspec only guarantees that the C result is
 `feq`-equal to the model value (equality up to `±0` and exceptional values), but once the result is finite,
@@ -88,21 +88,23 @@ copyright and license headers.
 | Sum of absolute values | double | `cblas_dasum` | [`src/dasum.c`](src/dasum.c), [`src/source_asum_r.h`](src/source_asum_r.h), [`include/cblas.h`](include/cblas.h), [`dasum.v`](dasum.v), [`asum_model.v`](asum_model.v), [`spec_dasum.v`](spec_dasum.v), [`verif_dasum.v`](verif_dasum.v) |
 | Scalar multiply (in place) | double | `cblas_dscal` | [`src/dscal.c`](src/dscal.c), [`src/source_scal_r.h`](src/source_scal_r.h), [`include/cblas.h`](include/cblas.h), [`dscal.v`](dscal.v), [`scal_model.v`](scal_model.v), [`spec_dscal.v`](spec_dscal.v), [`verif_dscal.v`](verif_dscal.v) |
 
-**Scope limits:**
-- `cblas_ddot` is currently **unit stride only** (`incX = incY = 1`).
-- `cblas_dasum` supports any positive stride; as in the GSL kernel, a nonpositive stride
-  returns `+0.0` without accessing the input array.
-- `cblas_dscal` supports any **positive stride**, subject to input-array bounds and a
-  signed-`int` bound on the final strided index.
-- For the **reductions** (`ddot`, `dasum`) the postcondition is stated up to `feq`.
-- `cblas_dasum` is verified against `sumF (map BABS X)`; its loop body calls `fabs`,
-  discharged with VSTlib's `fabs_spec` (whose result is `BABS`). The matching accuracy
-  theorem is `sum_acc.fSUM`.
-- `cblas_dscal` is the first **in-place** routine: it overwrites the array (writable share,
-  `void` return) and is verified against the exact model
-  `scal_strided incX N alpha X` (no `feq` required here). This model scales the `N`
-  positions selected by `incX` and leaves every unselected array element unchanged.
-  The per-element accuracy is a direct unit-roundoff bound on `BMULT`.
+**Scope and remaining limits:**
+
+- `cblas_ddot` supports positive, negative, and zero strides for both input arrays. Its
+  precondition ensures that every array access is in bounds and that computing and
+  updating the C array indices cannot overflow a signed `int`. The result is `feq`-equal
+  to `dotprodF` applied to the two logical strided vectors.
+- `cblas_dasum` supports every signed-`int` stride. For a positive stride, the result is
+  `feq`-equal to `sumF (map BABS (strided incX N X))`; for a nonpositive stride, the GSL
+  kernel returns `+0.0` without accessing the input array. The `fabs` call is verified with
+  VSTlib's `fabs_spec`.
+- `cblas_dscal` is currently specified only for positive strides. It updates the input
+  array in place and is verified exactly against `scal_strided incX N alpha X`, which
+  scales the selected elements and leaves every unselected element unchanged.
+- The proofs establish correspondence between the compiled C functions and the existing
+  LAProof functional models. Applying `dotprod_forward_error` or `fSUM` additionally
+  requires proving that the relevant model result is finite; this composition is not yet
+  packaged as a checked C-level accuracy theorem.
 
 ## Conventions
 

--- a/C/cblas/README.md
+++ b/C/cblas/README.md
@@ -35,13 +35,14 @@ however. To apply the bound to the C result, one must separately establish that 
 preconditions hold, and they fall into two kinds.
 
 - **Already guaranteed by the funspec precondition.** Some of the theorem's preconditions
-  are exactly things the funspec `PRE` already requires, so they hold for free (e.g. a
-  length precondition that the funspec already imposes on the input arrays).
+  are exactly things the funspec `PRE` already requires, so they hold for free (e.g. the
+  equal-length precondition that the `cblas_ddot` funspec imposes on the input arrays).
 - **Additional conditions one must discharge.** Other preconditions are not established by
-  the funspec and must be proved on the side. A typical example is a no-overflow assumption
-  that the accumulated result is finite: this does *not* follow from the funspec merely
-  requiring the inputs to be finite, since a combination of finite values can still
-  overflow to an infinity. Whoever applies the bound must supply this separately.
+  the funspec and must be proved on the side. The `cblas_ddot` and `cblas_dasum`
+  specifications deliberately accept arbitrary floating-point inputs, including infinities
+  and NaNs. Their accuracy theorems, however, require a no-overflow assumption that the
+  accumulated model result is finite. Thus, a proof of the absence of overflow must be
+  supplied separately for an accuracy bound to hold.
 
 So the honest statement is: for inputs satisfying both the funspec `PRE` and the accuracy
 theorem's own hypotheses, the bound holds of the C return value. In many cases (such as the
@@ -49,8 +50,9 @@ dot products and other reduction loops verified here) the one hypothesis the fun
 not already supply is a *no-overflow* condition: that the accumulated result is finite.
 
 For `cblas_ddot` that leftover precondition is exactly `Hfin`: that the accumulated result
-`dotprodF X Y` is finite. It does not follow merely from the inputs being finite, since a
-sum of finite products can still round to an infinity.
+`dotprodF X Y` is finite. Requiring finite inputs would not establish it anyway, since a
+sum of finite products can still round to an infinity. The corresponding condition for
+`cblas_dasum` is that `sumF (map BABS X)` is finite.
 
 The `feq` postcondition cooperates here: the funspec only guarantees that the C result is
 `feq`-equal to the model value (equality up to `±0` and exceptional values), but once the result is finite,
@@ -86,16 +88,20 @@ copyright and license headers.
 | Sum of absolute values | double | `cblas_dasum` | [`src/dasum.c`](src/dasum.c), [`src/source_asum_r.h`](src/source_asum_r.h), [`include/cblas.h`](include/cblas.h), [`dasum.v`](dasum.v), [`asum_model.v`](asum_model.v), [`spec_dasum.v`](spec_dasum.v), [`verif_dasum.v`](verif_dasum.v) |
 | Scalar multiply (in place) | double | `cblas_dscal` | [`src/dscal.c`](src/dscal.c), [`src/source_scal_r.h`](src/source_scal_r.h), [`include/cblas.h`](include/cblas.h), [`dscal.v`](dscal.v), [`scal_model.v`](scal_model.v), [`spec_dscal.v`](spec_dscal.v), [`verif_dscal.v`](verif_dscal.v) |
 
-**Scope limits (`cblas_ddot`, `cblas_dasum`, `cblas_dscal`):**
-- **Unit stride only** (`incX = incY = 1`), as a deliberate first milestone.
+**Scope limits:**
+- `cblas_ddot` and `cblas_dasum` are currently **unit stride only** (`incX = incY = 1`
+  for `ddot`, `incX = 1` for `dasum`), as a deliberate first milestone.
+- `cblas_dscal` supports any **positive stride**, subject to backing-buffer bounds and a
+  signed-`int` bound on the final strided index.
 - For the **reductions** (`ddot`, `dasum`) the postcondition is stated up to `feq`.
 - `cblas_dasum` is verified against `sumF (map BABS X)`; its loop body calls `fabs`,
   discharged with VSTlib's `fabs_spec` (whose result is `BABS`). The matching accuracy
   theorem is `sum_acc.fSUM`.
 - `cblas_dscal` is the first **in-place** routine: it overwrites the array (writable share,
-  `void` return) and is verified against an *exact* model `scal_model alpha X =
-  map (fun x => BMULT x alpha) X` (no `feq` required here). The
-  per-element accuracy is a direct unit-roundoff bound on `BMULT`.
+  `void` return) and is verified against the exact model
+  `scal_strided incX N alpha X` (no `feq` required here). This model scales the `N`
+  positions selected by `incX` and leaves every other entry in the backing buffer
+  unchanged. The per-element accuracy is a direct unit-roundoff bound on `BMULT`.
 
 ## Conventions
 

--- a/C/cblas/README.md
+++ b/C/cblas/README.md
@@ -35,8 +35,9 @@ however. To apply the bound to the C result, one must separately establish that 
 preconditions hold, and they fall into two kinds.
 
 - **Already guaranteed by the funspec precondition.** Some of the theorem's preconditions
-  are exactly things the funspec `PRE` already requires, so they hold for free (e.g. the
-  equal-length precondition that the `cblas_ddot` funspec imposes on the input arrays).
+  follow directly from the funspec and its logical model. For example, the two logical
+  strided vectors in the `cblas_ddot` postcondition both contain `N` elements, even though
+  their backing arrays may have different lengths.
 - **Additional conditions one must discharge.** Other preconditions are not established by
   the funspec and must be proved on the side. The `cblas_ddot` and `cblas_dasum`
   specifications deliberately accept arbitrary floating-point inputs, including infinities

--- a/C/cblas/README.md
+++ b/C/cblas/README.md
@@ -98,9 +98,10 @@ copyright and license headers.
   `feq`-equal to `sumF (map BABS (strided incX N X))`; for a nonpositive stride, the GSL
   kernel returns `+0.0` without accessing the input array. The `fabs` call is verified with
   VSTlib's `fabs_spec`.
-- `cblas_dscal` is currently specified only for positive strides. It updates the input
-  array in place and is verified exactly against `scal_strided incX N alpha X`, which
-  scales the selected elements and leaves every unselected element unchanged.
+- `cblas_dscal` supports every signed-`int` stride. For a positive stride, it updates the
+  input array in place and is verified exactly against `scal_strided incX N alpha X`,
+  which scales the selected elements and leaves every unselected element unchanged. For a
+  nonpositive stride, it returns without modifying the array.
 - The proofs establish correspondence between the compiled C functions and the existing
   LAProof functional models. Applying `dotprod_forward_error` or `fSUM` additionally
   requires proving that the relevant model result is finite; this composition is not yet

--- a/C/cblas/README.md
+++ b/C/cblas/README.md
@@ -89,9 +89,10 @@ copyright and license headers.
 | Scalar multiply (in place) | double | `cblas_dscal` | [`src/dscal.c`](src/dscal.c), [`src/source_scal_r.h`](src/source_scal_r.h), [`include/cblas.h`](include/cblas.h), [`dscal.v`](dscal.v), [`scal_model.v`](scal_model.v), [`spec_dscal.v`](spec_dscal.v), [`verif_dscal.v`](verif_dscal.v) |
 
 **Scope limits:**
-- `cblas_ddot` and `cblas_dasum` are currently **unit stride only** (`incX = incY = 1`
-  for `ddot`, `incX = 1` for `dasum`), as a deliberate first milestone.
-- `cblas_dscal` supports any **positive stride**, subject to backing-buffer bounds and a
+- `cblas_ddot` is currently **unit stride only** (`incX = incY = 1`).
+- `cblas_dasum` supports any positive stride; as in the GSL kernel, a nonpositive stride
+  returns `+0.0` without accessing the input array.
+- `cblas_dscal` supports any **positive stride**, subject to input-array bounds and a
   signed-`int` bound on the final strided index.
 - For the **reductions** (`ddot`, `dasum`) the postcondition is stated up to `feq`.
 - `cblas_dasum` is verified against `sumF (map BABS X)`; its loop body calls `fabs`,
@@ -100,8 +101,8 @@ copyright and license headers.
 - `cblas_dscal` is the first **in-place** routine: it overwrites the array (writable share,
   `void` return) and is verified against the exact model
   `scal_strided incX N alpha X` (no `feq` required here). This model scales the `N`
-  positions selected by `incX` and leaves every other entry in the backing buffer
-  unchanged. The per-element accuracy is a direct unit-roundoff bound on `BMULT`.
+  positions selected by `incX` and leaves every unselected array element unchanged.
+  The per-element accuracy is a direct unit-roundoff bound on `BMULT`.
 
 ## Conventions
 

--- a/C/cblas/ddot_model.v
+++ b/C/cblas/ddot_model.v
@@ -63,6 +63,16 @@ Lemma ddot_loop_snoc: forall xy p,
   ddot_loop (xy ++ [p]) = BPLUS (ddot_loop xy) (BMULT (fst p) (snd p)).
 Proof. intros. unfold ddot_loop. rewrite fold_left_app. reflexivity. Qed.
 
+Lemma ddot_model_snoc: forall X Y x y,
+  length X = length Y ->
+  ddot_model (X ++ [x]) (Y ++ [y]) =
+  BPLUS (ddot_model X Y) (BMULT x y).
+Proof.
+  intros. unfold ddot_model.
+  rewrite combine_app_eqlen by assumption.
+  cbn [combine]. rewrite ddot_loop_snoc. reflexivity.
+Qed.
+
 (** *step*: extending both length-[k] prefixes [X[0..k-1]]/[Y[0..k-1]] with the
     elements [X[k]]/[Y[k]] adds one [BMULT] term, with the accumulator as the
     first [BPLUS] operand -- exactly the Clight statement [r = r + X[k]*Y[k]]. *)

--- a/C/cblas/ddot_model.v
+++ b/C/cblas/ddot_model.v
@@ -93,10 +93,9 @@ Qed.
 Lemma ddot_model_feq_dotprodF:
   forall (X Y: list (ftype Tdouble)),
     Zlength X = Zlength Y ->
-    Forall finite X -> Forall finite Y ->
     feq (ddot_model X Y) (dotprodF X Y).
 Proof.
-  intros X Y Hlen _ _.
+  intros X Y Hlen.
   assert (Hl: length X = length Y)
     by (apply Nat2Z.inj; rewrite <- !Zlength_correct; exact Hlen).
   clear Hlen.

--- a/C/cblas/scal_model.v
+++ b/C/cblas/scal_model.v
@@ -35,3 +35,127 @@ Lemma Znth_scal_model: forall alpha X k,
   0 <= k < Zlength X ->
   Znth k (scal_model alpha X) = BMULT (Znth k X) alpha.
 Proof. intros. unfold scal_model. rewrite Znth_map by lia. reflexivity. Qed.
+
+(** ** Shared strided-access helper (used by [dscal], and later [dasum]/[ddot]). *)
+
+(** [strided incX N X] is the list of the [N] elements
+    [[Znth 0 X; Znth incX X; ...; Znth ((N-1)*incX) X]] -- exactly the elements a
+    GSL BLAS loop with stride [incX] touches in array [X].  It is a regular
+    *strided* selection (step [incX]) from a *contiguous* array.  It is NOT a
+    gather: a gather's addresses come from an index-vector *operand* (data) -- as
+    in [verif_sparse]'s [Znth (Znth h col_ind) vval], where the [col_ind] array
+    supplies the indices -- whereas here every index is derived from the single
+    scalar [incX] as [i*incX].  (The distinction is the *source* of the indices,
+    not their regularity: a gather's index vector could itself hold
+    [0; incX; 2*incX; ...].)  It is also NOT a contiguous prefix/[sublist].  The
+    lemma names follow VST's [Zlength_<f>]/[Znth_<f>] convention so
+    [list_solve]/[autorewrite with sublist] discharge length and element
+    side-goals automatically. *)
+Definition strided {A} `{Inhabitant A} (incX N : Z) (X : list A) : list A :=
+  map (fun i => Znth (i * incX) X) (upto (Z.to_nat N)).
+
+Lemma Zlength_strided: forall {A} `{Inhabitant A} incX N (X: list A),
+  0 <= N -> Zlength (strided incX N X) = N.
+Proof.
+  intros. unfold strided. rewrite Zlength_map, Zlength_upto, Z2Nat.id by lia. reflexivity.
+Qed.
+
+Lemma strided_snoc: forall {A} `{Inhabitant A} incX k (X: list A),
+  0 <= k -> strided incX (k+1) X = strided incX k X ++ [Znth (k*incX) X].
+Proof.
+  intros A ? incX k X Hk. unfold strided.
+  replace (Z.to_nat (k+1)) with (Z.to_nat k + 1)%nat by lia.
+  rewrite upto_app, map_app. f_equal.
+  cbn [upto map]. rewrite Z.add_0_r, Z2Nat.id by lia. reflexivity.
+Qed.
+
+(** ** Strided in-place scaling model (general positive stride [incX > 0]). *)
+
+(** [scal_strided incX N alpha X] is [X] with the [N] strided positions
+    [{i*incX : 0 <= i < N}] scaled by [alpha] and every other position unchanged
+    -- exactly the array state left by GSL's [cblas_dscal] loop at stride [incX].
+    It is a left fold of [upd_Znth] over the touched indices, so the loop
+    invariant can carry it directly and each store step is [scal_strided_snoc].
+    [src] holds the original values (the factor [BMULT (Znth (i*incX) src) alpha]
+    reads the *original* entry); [acc] is the running array. *)
+Definition scal_fold (incX: Z) (alpha: ftype Tdouble) (src: list (ftype Tdouble))
+                     (l: list Z) (acc: list (ftype Tdouble)) : list (ftype Tdouble) :=
+                     (* l is the list of iteration indices, not the data *)
+  fold_left (fun a i => upd_Znth (i*incX) a (BMULT (Znth (i*incX) src) alpha)) l acc.
+
+Definition scal_strided (incX N: Z) (alpha: ftype Tdouble) (X: list (ftype Tdouble))
+  : list (ftype Tdouble) :=
+  scal_fold incX alpha X (upto (Z.to_nat N)) X.
+
+Lemma scal_strided_0: forall incX alpha X, scal_strided incX 0 alpha X = X.
+Proof. reflexivity. Qed.
+
+Lemma Zlength_scal_fold: forall incX alpha src l acc,
+  (forall i, In i l -> 0 <= i*incX < Zlength acc) ->
+  Zlength (scal_fold incX alpha src l acc) = Zlength acc.
+Proof.
+  intros incX alpha src. unfold scal_fold.
+  induction l as [|a l IH]; intros acc Hin; [reflexivity|].
+  cbn [fold_left].
+  assert (Ha: 0 <= a*incX < Zlength acc) by (apply Hin; left; reflexivity).
+  rewrite IH.
+  - apply upd_Znth_Zlength; auto.
+  - intros i Hi. rewrite upd_Znth_Zlength by exact Ha. apply Hin; right; exact Hi.
+Qed.
+
+Lemma Znth_scal_fold_notin: forall incX alpha src l acc p,
+  0 <= p < Zlength acc ->
+  (forall i, In i l -> 0 <= i*incX < Zlength acc) ->
+  ~ In p (map (fun i => i*incX) l) ->
+  Znth p (scal_fold incX alpha src l acc) = Znth p acc.
+Proof.
+  intros incX alpha src. unfold scal_fold.
+  induction l as [|a l IH]; intros acc p Hp Hin Hnin; [reflexivity|].
+  cbn [fold_left].
+  assert (Ha: 0 <= a*incX < Zlength acc) by (apply Hin; left; reflexivity).
+  assert (Hne: p <> a*incX) by (intro Heq; apply Hnin; cbn [map]; left; symmetry; exact Heq).
+  set (acc' := upd_Znth (a*incX) acc (BMULT (Znth (a*incX) src) alpha)).
+  assert (Hlen: Zlength acc' = Zlength acc) by (subst acc'; apply upd_Znth_Zlength; auto).
+  transitivity (Znth p acc').
+  - apply IH.
+    + rewrite Hlen; exact Hp.
+    + intros i Hi. rewrite Hlen. apply Hin; right; exact Hi.
+    + intro Hc. apply Hnin; cbn [map]; right; exact Hc.
+  - subst acc'. apply upd_Znth_diff; auto.
+Qed.
+
+Lemma scal_strided_snoc: forall incX k alpha X, 0 <= k ->
+  scal_strided incX (k+1) alpha X
+  = upd_Znth (k*incX) (scal_strided incX k alpha X) (BMULT (Znth (k*incX) X) alpha).
+Proof.
+  intros incX k alpha X Hk. unfold scal_strided, scal_fold.
+  replace (Z.to_nat (k+1)) with (Z.to_nat k + 1)%nat by lia.
+  rewrite upto_app, fold_left_app.
+  cbn [upto map fold_left]. rewrite Z.add_0_r, Z2Nat.id by lia. reflexivity.
+Qed.
+
+Lemma Zlength_scal_strided: forall incX N alpha X,
+  0 <= N -> 0 < incX -> (N-1)*incX < Zlength X ->
+  Zlength (scal_strided incX N alpha X) = Zlength X.
+Proof.
+  intros incX N alpha X HN Hinc Hb. unfold scal_strided.
+  apply Zlength_scal_fold.
+  intros i Hi. rewrite In_upto, Z2Nat.id in Hi by lia. split; nia.
+Qed.
+
+(** The C kernel [X[ix] *= alpha] is a read-modify-write -- [X[ix] = X[ix] *
+    alpha] -- reading the current contents of [X[ix]] before storing back.  At
+    step [k] the slot [k*incX] is still untouched: prior writes hit [j*incX],
+    [j < k], all below [k*incX] since [incX > 0].  So the value read equals the
+    original [Znth (k*incX) X]. *)
+Lemma Znth_scal_strided_self: forall incX k alpha X,
+  0 <= k -> 0 < incX -> k*incX < Zlength X ->
+  Znth (k*incX) (scal_strided incX k alpha X) = Znth (k*incX) X.
+Proof.
+  intros incX k alpha X Hk Hinc Hkb. unfold scal_strided.
+  apply Znth_scal_fold_notin.
+  - split; [ nia | exact Hkb ].
+  - intros i Hi. rewrite In_upto, Z2Nat.id in Hi by lia. split; nia.
+  - rewrite in_map_iff. intros [j [Hj Hjin]].
+    rewrite In_upto, Z2Nat.id in Hjin by lia. nia.
+Qed.

--- a/C/cblas/scal_model.v
+++ b/C/cblas/scal_model.v
@@ -3,8 +3,8 @@
 
 (** This file provides two exact scaling models.  [scal_model] maps a scaling
     operation over an entire contiguous list; [scal_strided] models the general
-    positive-stride [cblas_dscal] proof by updating the selected positions in a
-    full backing buffer.  Scaling is a deterministic *elementwise* update with
+    positive-stride [cblas_dscal] proof by updating the selected positions in
+    the full input array.  Scaling is a deterministic *elementwise* update with
     no accumulation and needs no [feq] bridge.  GSL's kernel
     ([source_scal_r.h]) is
 <<
@@ -13,7 +13,7 @@
     i.e., [X[ix] *= alpha] is [BMULT (X[ix]) alpha] (element-first).
     [scal_model] below captures the contiguous whole-list special case; the
     later [scal_strided] definition captures the kernel for arbitrary positive
-    stride and a possibly larger backing buffer.
+    stride when the input array may contain unselected elements.
 
     LAProof's existing scale model [mv_mathcomp.scalemx] is alpha-first
     ([map_mx (BMULT a)]) and matrix-based; relating to it would need a [BMULT]

--- a/C/cblas/scal_model.v
+++ b/C/cblas/scal_model.v
@@ -39,7 +39,7 @@ Lemma Znth_scal_model: forall alpha X k,
   Znth k (scal_model alpha X) = BMULT (Znth k X) alpha.
 Proof. intros. unfold scal_model. rewrite Znth_map by lia. reflexivity. Qed.
 
-(** ** Shared strided-access helper (used by [dscal], and later [dasum]/[ddot]). *)
+(** ** Strided-access helper used by [dscal] and [dasum]. *)
 
 (** [strided incX N X] is the list of the [N] elements
     [[Znth 0 X; Znth incX X; ...; Znth ((N-1)*incX) X]] -- exactly the elements a

--- a/C/cblas/scal_model.v
+++ b/C/cblas/scal_model.v
@@ -1,16 +1,19 @@
 (**  * LAProof.C.cblas.scal_model: functional model of GSL's [cblas_dscal]. *)
 (** ** Corresponds to C program [C/cblas/src/dscal.c] (ported from GSL cblas). *)
 
-(** This file provides [scal_model], the elementwise scaling that [cblas_dscal]
-    computes.  Scaling is a deterministic *elementwise* update with no
-    accumulation, so there is no loop invariant tracking a running accumulator
-    and no [feq] bridge -- the C program computes the model exactly.  GSL's
-    kernel ([source_scal_r.h]) is
+(** This file provides two exact scaling models.  [scal_model] maps a scaling
+    operation over an entire contiguous list; [scal_strided] models the general
+    positive-stride [cblas_dscal] proof by updating the selected positions in a
+    full backing buffer.  Scaling is a deterministic *elementwise* update with
+    no accumulation and needs no [feq] bridge.  GSL's kernel
+    ([source_scal_r.h]) is
 <<
       for (i = 0; i < N; i++) { X[ix] *= alpha; ix += incX; }
 >>
-    i.e., [X[ix] *= alpha] is [BMULT (X[ix]) alpha] (element-first), so the model
-    is the list map below, matching what the C program computes.
+    i.e., [X[ix] *= alpha] is [BMULT (X[ix]) alpha] (element-first).
+    [scal_model] below captures the contiguous whole-list special case; the
+    later [scal_strided] definition captures the kernel for arbitrary positive
+    stride and a possibly larger backing buffer.
 
     LAProof's existing scale model [mv_mathcomp.scalemx] is alpha-first
     ([map_mx (BMULT a)]) and matrix-based; relating to it would need a [BMULT]

--- a/C/cblas/spec_dasum.v
+++ b/C/cblas/spec_dasum.v
@@ -24,8 +24,7 @@ Definition cblas_dasum_spec :=
  DECLARE _cblas_dasum
  WITH shX: share, n: Z, X: list (ftype Tdouble), px: val
  PRE [ tint, tptr tdouble, tint ]
-   PROP (readable_share shX; Zlength X = n; 0 <= n <= Int.max_signed;
-         Forall finite X)
+   PROP (readable_share shX; Zlength X = n; 0 <= n <= Int.max_signed)
    PARAMS (Vint (Int.repr n); px; Vint (Int.repr 1))
    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px)
  POST [ tdouble ]

--- a/C/cblas/spec_dasum.v
+++ b/C/cblas/spec_dasum.v
@@ -2,15 +2,15 @@
 (** ** Corresponds to C program [C/cblas/src/dasum.c] (ported from GSL cblas). *)
 
 (** Sibling of [LAProof.C.cblas.spec_ddot].  [cblas_dasum] computes the sum of
-    absolute values of a vector; the postcondition relates its result (up to
-    [feq]) to LAProof's summation model [sumF] applied to [map BABS X], over
-    which [sum_acc.fSUM] proves the forward-error bound. *)
+    absolute values of a strided vector; the postcondition relates its result
+    (up to [feq]) to LAProof's unchanged summation model [sumF], applied to the
+    logical vector selected from the input array by [incX]. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
 From VSTlib Require Import spec_math.
 From LAProof.C Require Import floatlib.
-From LAProof.C.cblas Require Import dasum asum_model.
+From LAProof.C.cblas Require Import dasum scal_model asum_model.
 (* for [sumF]; [Require Import] (not [Export]) keeps ssreflect out of scope. *)
 Require Import LAProof.accuracy_proofs.sum_model.
 
@@ -19,17 +19,29 @@ Set Bullet Behavior "Strict Subproofs".
 #[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
-(** ** Funspec for [cblas_dasum] (unit-stride case [incX = 1]). *)
+(** ** Funspec for [cblas_dasum] at general stride. *)
+(** For [incX > 0], the kernel reads [N] elements at positions [i*incX] in
+    the length-[n] input array.  The bounds cover those reads and the final
+    signed-[int] update of [ix].  For [incX <= 0], it returns [+0.0] without
+    accessing the array. *)
 Definition cblas_dasum_spec :=
  DECLARE _cblas_dasum
- WITH shX: share, n: Z, X: list (ftype Tdouble), px: val
+ WITH shX: share, n: Z, N: Z, incX: Z,
+      X: list (ftype Tdouble), px: val
  PRE [ tint, tptr tdouble, tint ]
-   PROP (readable_share shX; Zlength X = n; 0 <= n <= Int.max_signed)
-   PARAMS (Vint (Int.repr n); px; Vint (Int.repr 1))
+   PROP (readable_share shX; Zlength X = n; 0 <= n <= Int.max_signed;
+         0 <= N <= Int.max_signed;
+         Int.min_signed <= incX <= Int.max_signed;
+         incX <= 0 \/
+           (0 < incX /\ (N-1)*incX < n /\ N*incX <= Int.max_signed))
+   PARAMS (Vint (Int.repr N); px; Vint (Int.repr incX))
    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px)
  POST [ tdouble ]
    EX s: ftype Tdouble,
-   PROP (feq s (sumF (map BABS X)))
+   PROP (feq s
+     (if Z.leb incX 0
+      then Zconst Tdouble 0
+      else sumF (map BABS (strided incX N X))))
    RETURN (Vfloat s)
    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px).
 

--- a/C/cblas/spec_ddot.v
+++ b/C/cblas/spec_ddot.v
@@ -50,8 +50,7 @@ Definition cblas_ddot_spec :=
       px: val, py: val
  PRE [ tint, tptr tdouble, tint, tptr tdouble, tint ]
    PROP (readable_share shX; readable_share shY;
-         Zlength X = n; Zlength Y = n; 0 <= n <= Int.max_signed;
-         Forall finite X; Forall finite Y)
+         Zlength X = n; Zlength Y = n; 0 <= n <= Int.max_signed)
    PARAMS (Vint (Int.repr n); px; Vint (Int.repr 1); py; Vint (Int.repr 1))
    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
         data_at shY (tarray tdouble n) (map Vfloat Y) py)

--- a/C/cblas/spec_ddot.v
+++ b/C/cblas/spec_ddot.v
@@ -26,7 +26,7 @@
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
 From LAProof.C Require Import floatlib.
-From LAProof.C.cblas Require Import ddot ddot_model.
+From LAProof.C.cblas Require Import ddot stride_model ddot_model.
 (* [dotprod_model] only [Require Import]s (not [Export]s) the mathcomp preamble,
    so this does not pollute the VST namespace with ssreflect notations.  We need
    it here for [dotprodF], which the postcondition is stated against. *)
@@ -41,25 +41,43 @@ Definition Vprog : varspecs. mk_varspecs prog. Defined.
     live in [LAProof.C.cblas.ddot_model] (mirroring the [sparse_model] /
     [spec_sparse] split).  This file states only the VST [funspec]. *)
 
-(** ** Funspec for [cblas_ddot] (unit-stride case [incX = incY = 1]). *)
-(** Unit stride is a deliberate first milestone, not a fundamental limit. *)
+(** A stride is valid when GSL's initial [OFFSET] calculation, every selected
+    array index, and every signed-[int] index update are safe.  The strict lower
+    bound in the nonpositive case makes the C expression [-inc] defined when
+    [inc] is negative. *)
+Definition valid_ddot_stride (N inc n : Z) : Prop :=
+  Int.min_signed <= inc <= Int.max_signed /\
+  (inc <= 0 -> Int.min_signed < inc) /\
+  Int.min_signed <= blas_offset N inc <= Int.max_signed /\
+  (forall k, 0 <= k < N ->
+     0 <= blas_offset N inc + k*inc < n) /\
+  (forall k, 0 <= k < N ->
+     Int.min_signed <= blas_offset N inc + k*inc + inc <= Int.max_signed).
+
+(** ** Funspec for [cblas_ddot] at general stride. *)
 Definition cblas_ddot_spec :=
  DECLARE _cblas_ddot
- WITH shX: share, shY: share, n: Z,
+ WITH shX: share, shY: share, nX: Z, nY: Z, N: Z, incX: Z, incY: Z,
       X: list (ftype Tdouble), Y: list (ftype Tdouble),
       px: val, py: val
  PRE [ tint, tptr tdouble, tint, tptr tdouble, tint ]
    PROP (readable_share shX; readable_share shY;
-         Zlength X = n; Zlength Y = n; 0 <= n <= Int.max_signed)
-   PARAMS (Vint (Int.repr n); px; Vint (Int.repr 1); py; Vint (Int.repr 1))
-   SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
-        data_at shY (tarray tdouble n) (map Vfloat Y) py)
+         Zlength X = nX; Zlength Y = nY;
+         0 <= nX <= Int.max_signed; 0 <= nY <= Int.max_signed;
+         0 <= N <= Int.max_signed;
+         valid_ddot_stride N incX nX;
+         valid_ddot_stride N incY nY)
+   PARAMS (Vint (Int.repr N); px; Vint (Int.repr incX);
+           py; Vint (Int.repr incY))
+   SEP (data_at shX (tarray tdouble nX) (map Vfloat X) px;
+        data_at shY (tarray tdouble nY) (map Vfloat Y) py)
  POST [ tdouble ]
    EX s: ftype Tdouble,
-   PROP (feq s (dotprodF X Y))
+   PROP (feq s
+     (dotprodF (blas_strided incX N X) (blas_strided incY N Y)))
    RETURN (Vfloat s)
-   SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
-        data_at shY (tarray tdouble n) (map Vfloat Y) py).
+   SEP (data_at shX (tarray tdouble nX) (map Vfloat X) px;
+        data_at shY (tarray tdouble nY) (map Vfloat Y) py).
 
 Definition DdotASI : funspecs := [ cblas_ddot_spec ].
 Definition ddot_imports : funspecs := [].   (* no external calls: the loop is self-contained *)

--- a/C/cblas/spec_dscal.v
+++ b/C/cblas/spec_dscal.v
@@ -17,8 +17,9 @@ Set Bullet Behavior "Strict Subproofs".
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
 (** ** Funspec for [cblas_dscal] (general positive stride [incX > 0]). *)
-(** [X] is the full backing buffer ([Zlength X = n]); [N] is the element count
-    the loop scales, touching positions [{i*incX : 0 <= i < N}].  Memory safety
+(** [X] represents the entire input array ([Zlength X = n]); [N] is the
+    element count the loop scales, touching positions
+    [{i*incX : 0 <= i < N}].  Memory safety
     needs the last touched index in range ([(N-1)*incX < n]); [N*incX <=
     Int.max_signed] keeps the final [ix += incX] from overflowing [int].  GSL's
     kernel early-returns for [incX <= 0], so [incX = 0]/[incX < 0] are out of

--- a/C/cblas/spec_dscal.v
+++ b/C/cblas/spec_dscal.v
@@ -3,8 +3,8 @@
 
 (** [cblas_dscal] scales a vector in place by [alpha].  Because scaling is
     deterministic elementwise, the postcondition is stated as an *exact* equality
-    (the array is left holding [scal_model alpha X]); no [feq]/[EX] is needed,
-    unlike the reduction routines [ddot]/[dasum]. *)
+    (the array is left holding [scal_strided incX N alpha X]); no [feq]/[EX] is
+    needed, unlike the reduction routines [ddot]/[dasum]. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -16,19 +16,26 @@ Set Bullet Behavior "Strict Subproofs".
 #[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
-(** ** Funspec for [cblas_dscal] (unit-stride case [incX = 1]). *)
-(** Unit stride is a first milestone, not a fundamental limit.*)
+(** ** Funspec for [cblas_dscal] (general positive stride [incX > 0]). *)
+(** [X] is the full backing buffer ([Zlength X = n]); [N] is the element count
+    the loop scales, touching positions [{i*incX : 0 <= i < N}].  Memory safety
+    needs the last touched index in range ([(N-1)*incX < n]); [N*incX <=
+    Int.max_signed] keeps the final [ix += incX] from overflowing [int].  GSL's
+    kernel early-returns for [incX <= 0], so [incX = 0]/[incX < 0] are out of
+    scope here.  (Unit stride is the special case [incX = 1], [N = n].) *)
 Definition cblas_dscal_spec :=
  DECLARE _cblas_dscal
- WITH sh: share, n: Z, alpha: ftype Tdouble, X: list (ftype Tdouble), px: val
+ WITH sh: share, n: Z, N: Z, incX: Z, alpha: ftype Tdouble,
+      X: list (ftype Tdouble), px: val
  PRE [ tint, tdouble, tptr tdouble, tint ]
-   PROP (writable_share sh; Zlength X = n; 0 <= n <= Int.max_signed)
-   PARAMS (Vint (Int.repr n); Vfloat alpha; px; Vint (Int.repr 1))
+   PROP (writable_share sh; Zlength X = n; 0 <= n <= Int.max_signed;
+         0 <= N; 0 < incX <= Int.max_signed; (N-1)*incX < n; N*incX <= Int.max_signed)
+   PARAMS (Vint (Int.repr N); Vfloat alpha; px; Vint (Int.repr incX))
    SEP (data_at sh (tarray tdouble n) (map Vfloat X) px)
  POST [ tvoid ]
    PROP ()
    RETURN ()
-   SEP (data_at sh (tarray tdouble n) (map Vfloat (scal_model alpha X)) px).
+   SEP (data_at sh (tarray tdouble n) (map Vfloat (scal_strided incX N alpha X)) px).
 
 Definition DscalASI : funspecs := [ cblas_dscal_spec ].
 Definition dscal_imports : funspecs := [].   (* no external calls *)

--- a/C/cblas/spec_dscal.v
+++ b/C/cblas/spec_dscal.v
@@ -16,27 +16,31 @@ Set Bullet Behavior "Strict Subproofs".
 #[export] Instance CompSpecs : compspecs. make_compspecs prog. Defined.
 Definition Vprog : varspecs. mk_varspecs prog. Defined.
 
-(** ** Funspec for [cblas_dscal] (general positive stride [incX > 0]). *)
+(** ** Funspec for [cblas_dscal] at general stride. *)
 (** [X] represents the entire input array ([Zlength X = n]); [N] is the
     element count the loop scales, touching positions
     [{i*incX : 0 <= i < N}].  Memory safety
     needs the last touched index in range ([(N-1)*incX < n]); [N*incX <=
-    Int.max_signed] keeps the final [ix += incX] from overflowing [int].  GSL's
-    kernel early-returns for [incX <= 0], so [incX = 0]/[incX < 0] are out of
-    scope here.  (Unit stride is the special case [incX = 1], [N = n].) *)
+    Int.max_signed] keeps the final [ix += incX] from overflowing [int].  For
+    [incX <= 0], the GSL kernel returns without modifying the array. *)
 Definition cblas_dscal_spec :=
  DECLARE _cblas_dscal
  WITH sh: share, n: Z, N: Z, incX: Z, alpha: ftype Tdouble,
       X: list (ftype Tdouble), px: val
  PRE [ tint, tdouble, tptr tdouble, tint ]
    PROP (writable_share sh; Zlength X = n; 0 <= n <= Int.max_signed;
-         0 <= N; 0 < incX <= Int.max_signed; (N-1)*incX < n; N*incX <= Int.max_signed)
+         0 <= N <= Int.max_signed;
+         Int.min_signed <= incX <= Int.max_signed;
+         incX <= 0 \/
+           (0 < incX /\ (N-1)*incX < n /\ N*incX <= Int.max_signed))
    PARAMS (Vint (Int.repr N); Vfloat alpha; px; Vint (Int.repr incX))
    SEP (data_at sh (tarray tdouble n) (map Vfloat X) px)
  POST [ tvoid ]
    PROP ()
    RETURN ()
-   SEP (data_at sh (tarray tdouble n) (map Vfloat (scal_strided incX N alpha X)) px).
+   SEP (data_at sh (tarray tdouble n)
+          (map Vfloat
+            (if Z.leb incX 0 then X else scal_strided incX N alpha X)) px).
 
 Definition DscalASI : funspecs := [ cblas_dscal_spec ].
 Definition dscal_imports : funspecs := [].   (* no external calls *)

--- a/C/cblas/stride_model.v
+++ b/C/cblas/stride_model.v
@@ -1,0 +1,37 @@
+(** * Logical views of strided C arrays. *)
+
+Require Import VST.floyd.proofauto.
+
+Set Bullet Behavior "Strict Subproofs".
+
+(** [strided_from start inc N X] is the logical length-[N] vector whose
+    element [i] is stored at array index [start + i*inc]. *)
+Definition strided_from {A} `{Inhabitant A}
+    (start inc N : Z) (X : list A) : list A :=
+  map (fun i => Znth (start + i*inc) X) (upto (Z.to_nat N)).
+
+(** The starting index computed by GSL's [OFFSET(N,inc)] macro. *)
+Definition blas_offset (N inc : Z) : Z :=
+  if 0 <? inc then 0 else (N-1) * (-inc).
+
+Definition blas_strided {A} `{Inhabitant A}
+    (inc N : Z) (X : list A) : list A :=
+  strided_from (blas_offset N inc) inc N X.
+
+Lemma Zlength_strided_from: forall {A} `{Inhabitant A} start inc N (X: list A),
+  0 <= N -> Zlength (strided_from start inc N X) = N.
+Proof.
+  intros. unfold strided_from.
+  rewrite Zlength_map, Zlength_upto, Z2Nat.id by lia. reflexivity.
+Qed.
+
+Lemma strided_from_snoc: forall {A} `{Inhabitant A} start inc k (X: list A),
+  0 <= k ->
+  strided_from start inc (k+1) X =
+  strided_from start inc k X ++ [Znth (start + k*inc) X].
+Proof.
+  intros A ? start inc k X Hk. unfold strided_from.
+  replace (Z.to_nat (k+1)) with (Z.to_nat k + 1)%nat by lia.
+  rewrite upto_app, map_app. f_equal.
+  cbn [upto map]. rewrite Z.add_0_r, Z2Nat.id by lia. reflexivity.
+Qed.

--- a/C/cblas/verif_dasum.v
+++ b/C/cblas/verif_dasum.v
@@ -1,16 +1,15 @@
 (**  * LAProof.C.cblas.verif_dasum: VST proof for GSL's [cblas_dasum]. *)
 (** ** Corresponds to C program [C/cblas/src/dasum.c]. *)
 
-(** [body_cblas_dasum] proves that the compiled C [cblas_dasum] (unit stride)
-    returns a value [feq]-equal to [sumF (map BABS X)].  Its invariant uses
-    [asum_model] on the length-[k] prefix; supporting lemmas are in
-    [LAProof.C.cblas.asum_model]. *)
+(** [body_cblas_dasum] proves the positive-stride accumulation over
+    [strided incX N X] and the kernel's early return for [incX <= 0].  The
+    reduction models [asum_model] and [sumF] are unchanged. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
 From VSTlib Require Import spec_math.
 From LAProof.C Require Import floatlib.
-From LAProof.C.cblas Require Import dasum asum_model spec_dasum.
+From LAProof.C.cblas Require Import dasum scal_model asum_model spec_dasum.
 Require Import LAProof.accuracy_proofs.sum_model.
 
 Set Bullet Behavior "Strict Subproofs".
@@ -21,38 +20,49 @@ start_function.
 forward.
 forward.
 forward_if.
-{ rep_lia. }
-(* [_r] models the first [k] elements; unit stride makes [_ix = k]. *)
-forward_for_simple_bound (Zlength X)
+{ forward.
+  Exists (Zconst Tdouble 0).
+  entailer!!.
+  destruct (Z.leb incX 0) eqn:Hle; [reflexivity |].
+  apply Z.leb_gt in Hle; lia. }
+{ assert (Hinc: 0 < incX) by rep_lia.
+  assert (Hbounds: (N-1)*incX < n /\ N*incX <= Int.max_signed)
+    by (destruct H3 as [Hnonpos | [_ Hbounds]]; [lia | exact Hbounds]).
+  (* [_r] models the first [k] selected elements and [_ix = k*incX]. *)
+  forward_for_simple_bound N
   (EX k:Z,
     PROP ()
-    LOCAL (temp _r (Vfloat (asum_model (sublist 0 k X)));
-           temp _ix (Vint (Int.repr k));
-           temp _N (Vint (Int.repr (Zlength X)));
-           temp _incX (Vint (Int.repr 1));
+    LOCAL (temp _r (Vfloat (asum_model (strided incX k X)));
+           temp _ix (Vint (Int.repr (k*incX)));
+           temp _N (Vint (Int.repr N));
+           temp _incX (Vint (Int.repr incX));
            temp _X px)
-    SEP (data_at shX (tarray tdouble (Zlength X)) (map Vfloat X) px))%assert.
+    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px))%assert.
 -
   entailer!!.
 -
+  assert (Hib: 0 <= i*incX < n) by nia.
   forward.
-  forward_call (Znth i X).
-  forward.
-  forward.
-  entailer!!.
-  rewrite (asum_model_step X i) by list_solve.
-  reflexivity.
+  forward_call (Znth (i*incX) X).
+  + entailer!!.
+  + forward.
+    assert (Hov: 0 <= i*incX + incX <= Int.max_signed) by nia.
+    forward.
+    entailer!!.
+    rewrite strided_snoc by lia.
+    rewrite asum_loop_snoc.
+    split.
+    * reflexivity.
+    * do 2 f_equal. ring.
 -
   forward.
-  Exists (asum_model (sublist 0 (Zlength X) X)).
+  Exists (asum_model (strided incX N X)).
   entailer!!.
-  rewrite sublist_same by lia.
-  apply asum_model_feq_sumF.
+  destruct (Z.leb incX 0) eqn:Hle.
+  + apply Z.leb_le in Hle; lia.
+  + apply asum_model_feq_sumF. }
 Qed.
 
-(** Conditional accuracy payoff: the result is [feq]-equal to
-    [sumF (map BABS X)].  After additionally establishing that this model result
-    is finite (the accuracy theorem's [Hfin] hypothesis), one can transfer
-    [LAProof.accuracy_proofs.sum_acc.fSUM], applied to [map BABS X], to the value
-    computed by the compiled C [cblas_dasum].  That composition is not stated as
-    a checked theorem here; see [C/cblas/README.md]. *)
+(** For [incX > 0], the conditional accuracy payoff applies [fSUM] to
+    [map BABS (strided incX N X)] after establishing that its sum is finite.
+    The composition is not stated as a checked theorem here. *)

--- a/C/cblas/verif_dasum.v
+++ b/C/cblas/verif_dasum.v
@@ -2,12 +2,9 @@
 (** ** Corresponds to C program [C/cblas/src/dasum.c]. *)
 
 (** [body_cblas_dasum] proves that the compiled C [cblas_dasum] (unit stride)
-    refines LAProof's summation model: its result is [feq]-equal to
-    [sumF (map BABS X)].  The loop invariant carries the partial accumulation
-    [asum_model (sublist 0 k X)]; the step and bridge reasoning that discharges
-    it lives in [LAProof.C.cblas.asum_model].  The loop body makes an [fabs]
-    [forward_call], and a dead [if (incX<=0) return 0;] guard precedes the loop
-    (unreachable since [incX = 1]). *)
+    returns a value [feq]-equal to [sumF (map BABS X)].  Its invariant uses
+    [asum_model] on the length-[k] prefix; supporting lemmas are in
+    [LAProof.C.cblas.asum_model]. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -21,12 +18,11 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma body_cblas_dasum: semax_body Vprog Gprog f_cblas_dasum cblas_dasum_spec.
 Proof.
 start_function.
-forward.                       (* r = 0.0 *)
-forward.                       (* ix = 0 *)
-(* if (incX <= 0) return 0;  -- dead, incX = 1 *)
+forward.
+forward.
 forward_if.
-{ rep_lia. }                   (* then-branch: incX <= 0 contradicts incX = 1 *)
-(* accumulation loop *)
+{ rep_lia. }
+(* [_r] models the first [k] elements; unit stride makes [_ix = k]. *)
 forward_for_simple_bound (Zlength X)
   (EX k:Z,
     PROP ()
@@ -36,18 +32,18 @@ forward_for_simple_bound (Zlength X)
            temp _incX (Vint (Int.repr 1));
            temp _X px)
     SEP (data_at shX (tarray tdouble (Zlength X)) (map Vfloat X) px))%assert.
-- (* entry (k = 0): asum_model nil = +0.0 *)
+-
   entailer!!.
-- (* body: t = X[ix]; r += fabs(t); ix += incX *)
-  forward.                     (* t'2 = X[ix] *)
-  forward_call (Znth i X).     (* t'1 = fabs(X[i]) = BABS (Znth i X) *)
-  forward.                     (* r = r + t'1 *)
-  forward.                     (* ix = ix + incX *)
+-
+  forward.
+  forward_call (Znth i X).
+  forward.
+  forward.
   entailer!!.
   rewrite (asum_model_step X i) by list_solve.
   reflexivity.
-- (* exit (k = Zlength X): return r = asum_model X *)
-  forward.                     (* return r *)
+-
+  forward.
   Exists (asum_model (sublist 0 (Zlength X) X)).
   entailer!!.
   rewrite sublist_same by lia.

--- a/C/cblas/verif_dasum.v
+++ b/C/cblas/verif_dasum.v
@@ -54,7 +54,9 @@ forward_for_simple_bound (Zlength X)
   apply asum_model_feq_sumF.
 Qed.
 
-(** Payoff (stub): because the result is [feq]-equal to [sumF (map BABS X)], the
-    forward-error bound [LAProof.accuracy_proofs.sum_acc.fSUM] (applied to the
-    list [map BABS X]) bounds the C result's error whenever that result is finite
-    (the no-overflow hypothesis [Hfin]; see [C/cblas/README.md]). *)
+(** Conditional accuracy payoff: the result is [feq]-equal to
+    [sumF (map BABS X)].  After additionally establishing that this model result
+    is finite (the accuracy theorem's [Hfin] hypothesis), one can transfer
+    [LAProof.accuracy_proofs.sum_acc.fSUM], applied to [map BABS X], to the value
+    computed by the compiled C [cblas_dasum].  That composition is not stated as
+    a checked theorem here; see [C/cblas/README.md]. *)

--- a/C/cblas/verif_ddot.v
+++ b/C/cblas/verif_ddot.v
@@ -2,12 +2,9 @@
 (** ** Corresponds to C program [C/cblas/src/ddot.c]. *)
 
 (** [body_cblas_ddot] proves that the compiled C [cblas_ddot] (unit stride)
-    refines the [dotprodF] accuracy model: its result is [feq]-equal to
-    [dotprodF X Y].  The loop invariant carries the partial accumulation
-    [ddot_model (sublist 0 k X) (sublist 0 k Y)]; the step and bridge reasoning
-    that discharges it lives in [LAProof.C.cblas.ddot_model].  Two dead [OFFSET]
-    guards (the [incX>0]/[incY>0] conditionals) precede the loop, unreachable
-    since [incX = incY = 1]. *)
+    returns a value [feq]-equal to [dotprodF X Y].  Its invariant uses
+    [ddot_model] on length-[k] prefixes; the supporting lemmas are in
+    [LAProof.C.cblas.ddot_model]. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -20,7 +17,7 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma body_cblas_ddot: semax_body Vprog Gprog f_cblas_ddot cblas_ddot_spec.
 Proof.
 start_function.
-forward.                       (* _r = 0.0 *)
+forward.
 forward_if (PROP ()
   LOCAL (temp _t'1 (Vint (Int.repr 0));
          temp _r (Vfloat (Float.of_bits (Int64.repr 0)));
@@ -29,9 +26,9 @@ forward_if (PROP ()
          temp _incY (Vint (Int.repr 1)))
   SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
        data_at shY (tarray tdouble n) (map Vfloat Y) py)).
-{ forward. entailer!!. }       (* incX = 1 > 0 : t'1 := 0 *)
-{ rep_lia. }                   (* dead else-branch (incX = 1 is > 0) *)
-forward.                       (* _ix = _t'1 (= 0) *)
+{ forward. entailer!!. }
+{ rep_lia. }
+forward.
 forward_if (PROP ()
   LOCAL (temp _t'2 (Vint (Int.repr 0));
          temp _ix (Vint (Int.repr 0));
@@ -41,12 +38,10 @@ forward_if (PROP ()
          temp _incY (Vint (Int.repr 1)))
   SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
        data_at shY (tarray tdouble n) (map Vfloat Y) py)).
-{ forward. entailer!!. }       (* incY = 1 > 0 : t'2 := 0 *)
-{ rep_lia. }                   (* dead else-branch (incY = 1 is > 0) *)
-forward.                       (* _iy = _t'2 (= 0) *)
-(* The accumulation loop.  Invariant: _r holds the value the C loop has
-   accumulated over the first k element-pairs, namely [ddot_model] of the
-   length-k prefixes; the strided indices ix,iy advance by 1 each step (= k). *)
+{ forward. entailer!!. }
+{ rep_lia. }
+forward.
+(* [_r] models the first [k] pairs; unit stride makes [_ix = _iy = k]. *)
 forward_for_simple_bound n
   (EX k:Z,
     PROP ()
@@ -59,25 +54,21 @@ forward_for_simple_bound n
            temp _X px; temp _Y py)
     SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
          data_at shY (tarray tdouble n) (map Vfloat Y) py))%assert.
-- (* Loop entry (k = 0).  [sublist 0 0 = nil] and [ddot_model nil nil =
-     Zconst Tdouble 0] (= the C [+0.0]); [entailer!!] discharges it. *)
+-
   entailer!!.
-- (* Loop body: read X[i], Y[i]; [r = r + X[i]*Y[i]]; ix++; iy++.  Re-establish
-     the invariant for [i+1] via the step lemma [ddot_model_step]. *)
-  forward.                       (* t'3 = X[ix] *)
-  forward.                       (* t'4 = Y[iy] *)
-  forward.                       (* r = r + t'3 * t'4 *)
-  forward.                       (* ix = ix + incX *)
-  forward.                       (* iy = iy + incY *)
+-
+  forward.
+  forward.
+  forward.
+  forward.
+  forward.
   assert (Hi: 0 <= i < Zlength X) by list_solve.
   assert (Hxy: Zlength X = Zlength Y) by list_solve.
   entailer!.
   rewrite (ddot_model_step X Y i Hxy Hi).
   reflexivity.
-- (* Loop exit (k = n).  Return [r = ddot_model (sublist 0 n X) (sublist 0 n Y)];
-     [sublist_same] gives [= ddot_model X Y], and the bridge lemma
-     [ddot_model_feq_dotprodF] discharges [feq _ (dotprodF X Y)]. *)
-  forward.                       (* return r *)
+-
+  forward.
   Exists (ddot_model (sublist 0 (Zlength X) X) (sublist 0 (Zlength X) Y)).
   entailer!.
   rewrite (sublist_same 0 (Zlength X) X) by lia.

--- a/C/cblas/verif_ddot.v
+++ b/C/cblas/verif_ddot.v
@@ -1,15 +1,14 @@
 (**  * LAProof.C.cblas.verif_ddot: VST proof for GSL's [cblas_ddot]. *)
 (** ** Corresponds to C program [C/cblas/src/ddot.c]. *)
 
-(** [body_cblas_ddot] proves that the compiled C [cblas_ddot] (unit stride)
-    returns a value [feq]-equal to [dotprodF X Y].  Its invariant uses
-    [ddot_model] on length-[k] prefixes; the supporting lemmas are in
-    [LAProof.C.cblas.ddot_model]. *)
+(** [body_cblas_ddot] proves the accumulation over the logical vectors selected
+    by arbitrary signed strides, including zero.  The reduction models
+    [ddot_model] and [dotprodF] are unchanged. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
 From LAProof.C Require Import floatlib.
-From LAProof.C.cblas Require Import ddot ddot_model spec_ddot.
+From LAProof.C.cblas Require Import ddot stride_model ddot_model spec_ddot.
 Require Import LAProof.accuracy_proofs.dotprod_model.
 
 Set Bullet Behavior "Strict Subproofs".
@@ -17,68 +16,111 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma body_cblas_ddot: semax_body Vprog Gprog f_cblas_ddot cblas_ddot_spec.
 Proof.
 start_function.
+destruct H4 as (HincX & HnegX & HoffX & HidxX & HstepX).
+destruct H5 as (HincY & HnegY & HoffY & HidxY & HstepY).
+set (sx := blas_offset N incX).
+set (sy := blas_offset N incY).
 forward.
 forward_if (PROP ()
-  LOCAL (temp _t'1 (Vint (Int.repr 0));
+  LOCAL (temp _t'1 (Vint (Int.repr sx));
          temp _r (Vfloat (Float.of_bits (Int64.repr 0)));
-         temp _N (Vint (Int.repr n)); temp _X px;
-         temp _incX (Vint (Int.repr 1)); temp _Y py;
-         temp _incY (Vint (Int.repr 1)))
-  SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
-       data_at shY (tarray tdouble n) (map Vfloat Y) py)).
-{ forward. entailer!!. }
-{ rep_lia. }
+         temp _N (Vint (Int.repr N)); temp _X px;
+         temp _incX (Vint (Int.repr incX)); temp _Y py;
+         temp _incY (Vint (Int.repr incY)))
+  SEP (data_at shX (tarray tdouble nX) (map Vfloat X) px;
+       data_at shY (tarray tdouble nY) (map Vfloat Y) py)).
+{ forward. entailer!!.
+  subst sx. unfold blas_offset.
+  destruct (0 <? incX) eqn:Hlt; [reflexivity |].
+  apply Z.ltb_ge in Hlt; lia. }
+{ assert (Hincmin: Int.min_signed < incX) by (apply HnegX; lia).
+  assert (Hminus: Int.min_signed <= -incX <= Int.max_signed) by rep_lia.
+  assert (Hprod: Int.min_signed <= (N-1)*(-incX) <= Int.max_signed).
+  { subst sx. unfold blas_offset in HoffX.
+    destruct (0 <? incX) eqn:Hlt.
+    - apply Z.ltb_lt in Hlt; lia.
+    - exact HoffX. }
+  forward. entailer!!.
+  subst sx. unfold blas_offset.
+  destruct (0 <? incX) eqn:Hlt.
+  - apply Z.ltb_lt in Hlt; lia.
+  - reflexivity. }
 forward.
 forward_if (PROP ()
-  LOCAL (temp _t'2 (Vint (Int.repr 0));
-         temp _ix (Vint (Int.repr 0));
+  LOCAL (temp _t'2 (Vint (Int.repr sy));
+         temp _ix (Vint (Int.repr sx));
          temp _r (Vfloat (Float.of_bits (Int64.repr 0)));
-         temp _N (Vint (Int.repr n)); temp _X px;
-         temp _incX (Vint (Int.repr 1)); temp _Y py;
-         temp _incY (Vint (Int.repr 1)))
-  SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
-       data_at shY (tarray tdouble n) (map Vfloat Y) py)).
-{ forward. entailer!!. }
-{ rep_lia. }
+         temp _N (Vint (Int.repr N)); temp _X px;
+         temp _incX (Vint (Int.repr incX)); temp _Y py;
+         temp _incY (Vint (Int.repr incY)))
+  SEP (data_at shX (tarray tdouble nX) (map Vfloat X) px;
+       data_at shY (tarray tdouble nY) (map Vfloat Y) py)).
+{ forward. entailer!!.
+  subst sy. unfold blas_offset.
+  destruct (0 <? incY) eqn:Hlt; [reflexivity |].
+  apply Z.ltb_ge in Hlt; lia. }
+{ assert (Hincmin: Int.min_signed < incY) by (apply HnegY; lia).
+  assert (Hminus: Int.min_signed <= -incY <= Int.max_signed) by rep_lia.
+  assert (Hprod: Int.min_signed <= (N-1)*(-incY) <= Int.max_signed).
+  { subst sy. unfold blas_offset in HoffY.
+    destruct (0 <? incY) eqn:Hlt.
+    - apply Z.ltb_lt in Hlt; lia.
+    - exact HoffY. }
+  forward. entailer!!.
+  subst sy. unfold blas_offset.
+  destruct (0 <? incY) eqn:Hlt.
+  - apply Z.ltb_lt in Hlt; lia.
+  - reflexivity. }
 forward.
-(* [_r] models the first [k] pairs; unit stride makes [_ix = _iy = k]. *)
-forward_for_simple_bound n
+(* [_r] models the first [k] selected pairs. *)
+forward_for_simple_bound N
   (EX k:Z,
     PROP ()
-    LOCAL (temp _r (Vfloat (ddot_model (sublist 0 k X) (sublist 0 k Y)));
-           temp _ix (Vint (Int.repr k));
-           temp _iy (Vint (Int.repr k));
-           temp _N (Vint (Int.repr n));
-           temp _incX (Vint (Int.repr 1));
-           temp _incY (Vint (Int.repr 1));
+    LOCAL (temp _r (Vfloat
+             (ddot_model (strided_from sx incX k X)
+                         (strided_from sy incY k Y)));
+           temp _ix (Vint (Int.repr (sx + k*incX)));
+           temp _iy (Vint (Int.repr (sy + k*incY)));
+           temp _N (Vint (Int.repr N));
+           temp _incX (Vint (Int.repr incX));
+           temp _incY (Vint (Int.repr incY));
            temp _X px; temp _Y py)
-    SEP (data_at shX (tarray tdouble n) (map Vfloat X) px;
-         data_at shY (tarray tdouble n) (map Vfloat Y) py))%assert.
+    SEP (data_at shX (tarray tdouble nX) (map Vfloat X) px;
+         data_at shY (tarray tdouble nY) (map Vfloat Y) py))%assert.
 -
   entailer!!.
 -
+  assert (Hix: 0 <= sx + i*incX < nX)
+    by (subst sx; apply HidxX; lia).
+  assert (Hiy: 0 <= sy + i*incY < nY)
+    by (subst sy; apply HidxY; lia).
   forward.
   forward.
   forward.
+  assert (Hsx: Int.min_signed <= sx + i*incX + incX <= Int.max_signed)
+    by (subst sx; apply HstepX; lia).
+  assert (Hsy: Int.min_signed <= sy + i*incY + incY <= Int.max_signed)
+    by (subst sy; apply HstepY; lia).
   forward.
   forward.
-  assert (Hi: 0 <= i < Zlength X) by list_solve.
-  assert (Hxy: Zlength X = Zlength Y) by list_solve.
   entailer!.
-  rewrite (ddot_model_step X Y i Hxy Hi).
-  reflexivity.
+  rewrite !strided_from_snoc by lia.
+  rewrite ddot_model_snoc.
+  + repeat split; do 2 f_equal; ring.
+  + apply Nat2Z.inj. rewrite <- !Zlength_correct.
+    rewrite !Zlength_strided_from by lia. reflexivity.
 -
   forward.
-  Exists (ddot_model (sublist 0 (Zlength X) X) (sublist 0 (Zlength X) Y)).
+  Exists (ddot_model (strided_from sx incX N X) (strided_from sy incY N Y)).
   entailer!.
-  rewrite (sublist_same 0 (Zlength X) X) by lia.
-  rewrite (sublist_same 0 (Zlength X) Y) by lia.
-  apply ddot_model_feq_dotprodF; lia.
+  unfold blas_strided. fold sx sy.
+  apply ddot_model_feq_dotprodF.
+  rewrite !Zlength_strided_from by lia. reflexivity.
 Qed.
 
-(** Conditional accuracy payoff: [cblas_ddot_spec]'s result is [feq]-equal to
-    [dotprodF X Y].  After additionally establishing that [dotprodF X Y] is
-    finite (the accuracy theorem's [Hfin] hypothesis), one can transfer
+(** Conditional accuracy payoff: the result is [feq]-equal to [dotprodF]
+    applied to the two logical strided vectors.  After additionally establishing
+    that this model result is finite, one can transfer
     [LAProof.accuracy_proofs.dot_acc.dotprod_forward_error] to the value computed
     by the compiled C [cblas_ddot].  That composition is not stated as a checked
     theorem here. *)

--- a/C/cblas/verif_ddot.v
+++ b/C/cblas/verif_ddot.v
@@ -85,7 +85,9 @@ forward_for_simple_bound n
   apply ddot_model_feq_dotprodF; lia.
 Qed.
 
-(** Payoff: because [cblas_ddot_spec]'s result is [feq]-equal to
-    [dotprodF X Y], the forward-error bound
-    [LAProof.accuracy_proofs.dot_acc.dotprod_forward_error] applies directly to
-    the value computed by the compiled C [cblas_ddot]. *)
+(** Conditional accuracy payoff: [cblas_ddot_spec]'s result is [feq]-equal to
+    [dotprodF X Y].  After additionally establishing that [dotprodF X Y] is
+    finite (the accuracy theorem's [Hfin] hypothesis), one can transfer
+    [LAProof.accuracy_proofs.dot_acc.dotprod_forward_error] to the value computed
+    by the compiled C [cblas_ddot].  That composition is not stated as a checked
+    theorem here. *)

--- a/C/cblas/verif_ddot.v
+++ b/C/cblas/verif_ddot.v
@@ -20,9 +20,6 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma body_cblas_ddot: semax_body Vprog Gprog f_cblas_ddot cblas_ddot_spec.
 Proof.
 start_function.
-(* C: r = 0.0; ix = OFFSET(N,incX); iy = OFFSET(N,incY); with incX=incY=1 ⇒ ix=iy=0.
-   Each OFFSET is a (incX>0 ? 0 : ...) conditional; the else-branch is
-   unreachable here because incX=incY=1, so [rep_lia] closes it. *)
 forward.                       (* _r = 0.0 *)
 forward_if (PROP ()
   LOCAL (temp _t'1 (Vint (Int.repr 0));
@@ -85,10 +82,10 @@ forward_for_simple_bound n
   entailer!.
   rewrite (sublist_same 0 (Zlength X) X) by lia.
   rewrite (sublist_same 0 (Zlength X) Y) by lia.
-  apply ddot_model_feq_dotprodF; [ lia | auto | auto ].
+  apply ddot_model_feq_dotprodF; lia.
 Qed.
 
-(** Payoff (stub): because [cblas_ddot_spec]'s result is [feq]-equal to
+(** Payoff: because [cblas_ddot_spec]'s result is [feq]-equal to
     [dotprodF X Y], the forward-error bound
     [LAProof.accuracy_proofs.dot_acc.dotprod_forward_error] applies directly to
     the value computed by the compiled C [cblas_ddot]. *)

--- a/C/cblas/verif_dscal.v
+++ b/C/cblas/verif_dscal.v
@@ -1,11 +1,8 @@
 (**  * LAProof.C.cblas.verif_dscal: VST proof for GSL's [cblas_dscal]. *)
 (** ** Corresponds to C program [C/cblas/src/dscal.c]. *)
 
-(** [body_cblas_dscal] proves that after the compiled C [cblas_dscal] (general
-    positive stride [incX > 0]) the array holds exactly [scal_strided incX N
-    alpha X].  The invariant tracks that model after [i] stores with
-    [_ix = i*incX]; [Znth_scal_strided_self] shows that the next position still
-    contains its original value. *)
+(** [body_cblas_dscal] proves the positive-stride updates described by
+    [scal_strided] and the kernel's unchanged-array result for [incX <= 0]. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -19,9 +16,15 @@ Proof.
 start_function.
 forward.
 forward_if.
-{ rep_lia. }
-(* [L] contains the [k] completed updates and [_ix = k*incX]. *)
-forward_for_simple_bound N
+{ forward. entailer!!.
+  destruct (Z.leb incX 0) eqn:Hle.
+  - cancel.
+  - apply Z.leb_gt in Hle; lia. }
+{ assert (Hinc: 0 < incX) by rep_lia.
+  assert (Hbounds: (N-1)*incX < n /\ N*incX <= Int.max_signed)
+    by (destruct H3 as [Hnonpos | [_ Hbounds]]; [lia | exact Hbounds]).
+  (* [L] contains the [k] completed updates and [_ix = k*incX]. *)
+  forward_for_simple_bound N
   (EX k:Z, EX L:list (ftype Tdouble),
     PROP (L = scal_strided incX k alpha X; Zlength L = n)
     LOCAL (temp _alpha (Vfloat alpha);
@@ -62,11 +65,11 @@ forward_for_simple_bound N
   Intros L.
   assert (HL: L = scal_strided incX N alpha X) by assumption.
   subst L. entailer!!.
+  destruct (Z.leb incX 0) eqn:Hle.
+  + apply Z.leb_le in Hle; lia.
+  + cancel. }
 Qed.
 
-(** Payoff: each element [BMULT (Znth k X) alpha] is the correctly-rounded
-    product, so when that product is finite its relative error vs the exact
-    product is bounded by the unit roundoff (vcfloat's [BMULT] accuracy lemma).
-    A product can still overflow, but the finiteness (no-overflow) requirement is
-    per element -- each [X[k]*alpha] independently -- rather than a single global
-    hypothesis over an accumulation. *)
+(** In the positive-stride branch, each updated element is a correctly rounded
+    [BMULT].  Its relative-error bound requires that product to be finite; this
+    is a per-element condition rather than a global accumulation hypothesis. *)

--- a/C/cblas/verif_dscal.v
+++ b/C/cblas/verif_dscal.v
@@ -3,12 +3,9 @@
 
 (** [body_cblas_dscal] proves that after the compiled C [cblas_dscal] (general
     positive stride [incX > 0]) the array holds exactly [scal_strided incX N
-    alpha X].  This is an in-place routine: a writable array with a store in the
-    loop.  The loop counter [_i] runs [0..N) while the address [_ix] advances by
-    [incX] (so [_ix = i*incX]); the invariant carries [scal_strided incX i alpha
-    X] directly, and each store step is one [scal_strided_snoc].  The value read
-    at [X[ix]] is the *original* entry because position [i*incX] has not been
-    written yet ([Znth_scal_strided_self]). *)
+    alpha X].  The invariant tracks that model after [i] stores with
+    [_ix = i*incX]; [Znth_scal_strided_self] shows that the next position still
+    contains its original value. *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -20,13 +17,10 @@ Set Bullet Behavior "Strict Subproofs".
 Lemma body_cblas_dscal: semax_body Vprog Gprog f_cblas_dscal cblas_dscal_spec.
 Proof.
 start_function.
-forward.                       (* ix = 0 *)
+forward.
 forward_if.
-{ (* dead: the [incX <= 0] guard contradicts [0 < incX] *) rep_lia. }
-(* Invariant: the array holds [scal_strided incX k alpha X] (the [k] strided
-   positions already scaled, all others untouched).  The address [_ix] tracks
-   [k*incX].  Carrying the model directly makes each store step exactly
-   [scal_strided_snoc]. *)
+{ rep_lia. }
+(* [L] contains the [k] completed updates and [_ix = k*incX]. *)
 forward_for_simple_bound N
   (EX k:Z, EX L:list (ftype Tdouble),
     PROP (L = scal_strided incX k alpha X; Zlength L = n)
@@ -36,36 +30,35 @@ forward_for_simple_bound N
            temp _incX (Vint (Int.repr incX));
            temp _X px)
     SEP (data_at sh (tarray tdouble n) (map Vfloat L) px))%assert.
-- (* entry (k = 0): [L := X = scal_strided incX 0 alpha X], [_ix = 0*incX = 0] *)
+-
   Exists X. rewrite scal_strided_0. entailer!!.
-- (* body (counter [i], 0 <= i < N): t = X[ix]; X[ix] = t*alpha; ix += incX *)
+-
   Intros.
   assert (HL: L = scal_strided incX i alpha X) by assumption.
   assert (Hlen: Zlength L = n) by assumption.
   assert (Hib: 0 <= i*incX < n) by nia.
   assert (Hself: Znth (i*incX) L = Znth (i*incX) X)
     by (rewrite HL; apply Znth_scal_strided_self; [ lia | lia | lia ]).
-  forward.                     (* t'1 = X[ix] *)
-  forward.                     (* X[ix] = t'1 * alpha *)
-  (* [ix + incX] is signed [int] addition; supply the no-overflow bound
-     [(i+1)*incX <= N*incX <= Int.max_signed] for [forward]'s tc solver. *)
+  forward.
+  forward.
+  (* Bound the signed addition used to advance [_ix]. *)
   assert (Hov: 0 <= i*incX + incX <= Int.max_signed) by nia.
-  forward.                     (* ix = ix + incX *)
+  forward.
   Exists (upd_Znth (i*incX) L (BMULT (Znth (i*incX) L) alpha)).
   entailer!!.
-  2: { (* SEP: the stored value [X[ix]*alpha] is the model element [BMULT .. alpha] *)
+  2: {
        assert (Hib': 0 <= i*incX < Zlength (scal_strided incX i alpha X))
          by (rewrite Hlen; exact Hib).
        apply derives_refl'. f_equal. rewrite <- upd_Znth_map. f_equal.
        rewrite Znth_map by exact Hib'. reflexivity. }
   split.
-  + (* the updated list is [scal_strided incX (i+1) alpha X] *)
+  +
     rewrite scal_strided_snoc by lia. f_equal. rewrite Hself. reflexivity.
-  + (* Zlength preserved, and [_ix = (i+1)*incX = i*incX + incX] *)
+  +
     split.
     * rewrite upd_Znth_Zlength by (rewrite Hlen; exact Hib). exact Hlen.
     * do 2 f_equal. ring.
-- (* exit (k = N): the whole array now holds [scal_strided incX N alpha X] *)
+-
   Intros L.
   assert (HL: L = scal_strided incX N alpha X) by assumption.
   subst L. entailer!!.

--- a/C/cblas/verif_dscal.v
+++ b/C/cblas/verif_dscal.v
@@ -1,11 +1,14 @@
 (**  * LAProof.C.cblas.verif_dscal: VST proof for GSL's [cblas_dscal]. *)
 (** ** Corresponds to C program [C/cblas/src/dscal.c]. *)
 
-(** [body_cblas_dscal] proves that after the compiled C [cblas_dscal] (unit
-    stride) the array holds exactly [scal_model alpha X] (= [map (fun x => BMULT
-    x alpha) X]).  This is an in-place routine: a writable array with a store in
-    the loop, whose invariant is "scaled prefix ++ original suffix"; the per-step
-    [upd_Znth]/[sublist] identity is discharged by [list_solve]. *)
+(** [body_cblas_dscal] proves that after the compiled C [cblas_dscal] (general
+    positive stride [incX > 0]) the array holds exactly [scal_strided incX N
+    alpha X].  This is an in-place routine: a writable array with a store in the
+    loop.  The loop counter [_i] runs [0..N) while the address [_ix] advances by
+    [incX] (so [_ix = i*incX]); the invariant carries [scal_strided incX i alpha
+    X] directly, and each store step is one [scal_strided_snoc].  The value read
+    at [X[ix]] is the *original* entry because position [i*incX] has not been
+    written yet ([Znth_scal_strided_self]). *)
 
 Require Import VST.floyd.proofauto.
 From vcfloat Require Import FPStdCompCert FPStdLib.
@@ -19,61 +22,52 @@ Proof.
 start_function.
 forward.                       (* ix = 0 *)
 forward_if.
-{ rep_lia. }                   (* dead: incX <= 0 contradicts incX = 1 *)
-(* Invariant: the array holds a list [L] of length [Zlength X] whose first [k]
-   entries are already scaled ([Znth j X * alpha]) and whose remaining entries
-   are still the original [X].  Keeping the contents as [map Vfloat L] for a
-   *plain* list [L] lets the load and store simplify; the pointwise [Znth]
-   constraints make each step a simple [upd_Znth_same]/[upd_Znth_diff] case. *)
-forward_for_simple_bound (Zlength X)
+{ (* dead: the [incX <= 0] guard contradicts [0 < incX] *) rep_lia. }
+(* Invariant: the array holds [scal_strided incX k alpha X] (the [k] strided
+   positions already scaled, all others untouched).  The address [_ix] tracks
+   [k*incX].  Carrying the model directly makes each store step exactly
+   [scal_strided_snoc]. *)
+forward_for_simple_bound N
   (EX k:Z, EX L:list (ftype Tdouble),
-    PROP (Zlength L = Zlength X;
-          forall j, 0 <= j < k -> Znth j L = (Znth j X * alpha)%F64;
-          forall j, k <= j < Zlength X -> Znth j L = Znth j X)
+    PROP (L = scal_strided incX k alpha X; Zlength L = n)
     LOCAL (temp _alpha (Vfloat alpha);
-           temp _ix (Vint (Int.repr k));
-           temp _N (Vint (Int.repr (Zlength X)));
-           temp _incX (Vint (Int.repr 1));
+           temp _ix (Vint (Int.repr (k*incX)));
+           temp _N (Vint (Int.repr N));
+           temp _incX (Vint (Int.repr incX));
            temp _X px)
-    SEP (data_at sh (tarray tdouble (Zlength X)) (map Vfloat L) px))%assert.
-- (* entry (k = 0): L := X *)
-  Exists X. entailer!!.
-- (* body: t = X[ix]; X[ix] = t * alpha; ix += incX *)
+    SEP (data_at sh (tarray tdouble n) (map Vfloat L) px))%assert.
+- (* entry (k = 0): [L := X = scal_strided incX 0 alpha X], [_ix = 0*incX = 0] *)
+  Exists X. rewrite scal_strided_0. entailer!!.
+- (* body (counter [i], 0 <= i < N): t = X[ix]; X[ix] = t*alpha; ix += incX *)
   Intros.
-  (* Re-assert the invariant facts under explicit names so they survive the
-     [forward]s (which clear the auto-named PROP hypotheses). *)
-  assert (Hlen: Zlength L = Zlength X) by assumption.
-  assert (Hpre: forall j, 0 <= j < i -> Znth j L = (Znth j X * alpha)%F64) by assumption.
-  assert (Hsuf: forall j, i <= j < Zlength X -> Znth j L = Znth j X) by assumption.
-  assert (Hi: 0 <= i < Zlength L) by lia.
-  assert (HLX: Znth i L = Znth i X) by (apply Hsuf; lia).
+  assert (HL: L = scal_strided incX i alpha X) by assumption.
+  assert (Hlen: Zlength L = n) by assumption.
+  assert (Hib: 0 <= i*incX < n) by nia.
+  assert (Hself: Znth (i*incX) L = Znth (i*incX) X)
+    by (rewrite HL; apply Znth_scal_strided_self; [ lia | lia | lia ]).
   forward.                     (* t'1 = X[ix] *)
   forward.                     (* X[ix] = t'1 * alpha *)
-  forward.                     (* ix += incX *)
-  Exists (upd_Znth i L (BMULT (Znth i X) alpha)).
+  (* [ix + incX] is signed [int] addition; supply the no-overflow bound
+     [(i+1)*incX <= N*incX <= Int.max_signed] for [forward]'s tc solver. *)
+  assert (Hov: 0 <= i*incX + incX <= Int.max_signed) by nia.
+  forward.                     (* ix = ix + incX *)
+  Exists (upd_Znth (i*incX) L (BMULT (Znth (i*incX) L) alpha)).
   entailer!!.
-  2: { (* SEP: the stored value [X[i]*alpha] is the model element [BMULT .. alpha] *)
+  2: { (* SEP: the stored value [X[ix]*alpha] is the model element [BMULT .. alpha] *)
+       assert (Hib': 0 <= i*incX < Zlength (scal_strided incX i alpha X))
+         by (rewrite Hlen; exact Hib).
        apply derives_refl'. f_equal. rewrite <- upd_Znth_map. f_equal.
-       rewrite ?Znth_map by lia.
-       replace (@Znth float Inhabitant_float i L)
-          with (@Znth float Inhabitant_float i X) by (symmetry; apply HLX).
-       reflexivity. }
-  (* the three pointwise list invariants for the updated list *)
-  split3.
-  { list_solve. }
-  { intros j Hj. destruct (Z.eq_dec j i) as [->|Hne].
-    { rewrite upd_Znth_same by lia. reflexivity. }
-    { rewrite upd_Znth_diff by lia. apply Hpre; lia. } }
-  { intros j Hj. rewrite upd_Znth_diff by lia. apply Hsuf; lia. }
-- (* exit (k = Zlength X): the whole array now holds [scal_model alpha X] *)
+       rewrite Znth_map by exact Hib'. reflexivity. }
+  split.
+  + (* the updated list is [scal_strided incX (i+1) alpha X] *)
+    rewrite scal_strided_snoc by lia. f_equal. rewrite Hself. reflexivity.
+  + (* Zlength preserved, and [_ix = (i+1)*incX = i*incX + incX] *)
+    split.
+    * rewrite upd_Znth_Zlength by (rewrite Hlen; exact Hib). exact Hlen.
+    * do 2 f_equal. ring.
+- (* exit (k = N): the whole array now holds [scal_strided incX N alpha X] *)
   Intros L.
-  assert (Hpre: forall j, 0 <= j < Zlength X -> Znth j L = (Znth j X * alpha)%F64)
-    by assumption.
-  assert (Hlen: Zlength L = Zlength X) by assumption.
-  assert (L = scal_model alpha X). {
-    apply Znth_eq_ext; [ rewrite Zlength_scal_model; lia | ].
-    intros j Hj. rewrite Hlen in Hj.
-    rewrite Znth_scal_model by lia. rewrite Hpre by lia. reflexivity. }
+  assert (HL: L = scal_strided incX N alpha X) by assumption.
   subst L. entailer!!.
 Qed.
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -60,5 +60,6 @@ C/cblas/verif_dasum.v
 
 C/cblas/dscal.v
 C/cblas/scal_model.v
+C/cblas/stride_model.v
 C/cblas/spec_dscal.v
 C/cblas/verif_dscal.v


### PR DESCRIPTION
## Summary

Generalizes the VST verification of the GSL CBLAS Level-1 routines from unit stride to their supported signed-stride behavior.

- Generalizes `cblas_ddot` to positive, negative, and zero strides for both input arrays, subject to preconditions ensuring that the GSL offset calculation, array accesses, and signed-`int` index updates are safe.
- Generalizes `cblas_dasum` to positive strides and verifies that, for nonpositive strides, the GSL kernel returns `+0.0` without accessing the input array.
- Generalizes `cblas_dscal` to positive strides and verifies that, for nonpositive strides, the GSL kernel returns without modifying the input array.
- Generalizes the funspecs, loop invariants, and VST proofs for all three routines.
- Removes unnecessary input-finiteness assumptions from the `ddot` and `dasum` funspecs and the `ddot` bridge lemma.
- Updates the CBLAS documentation to describe the supported stride behavior and remaining obligations for applying the accuracy theorems.

## Model changes

- Adds `C/cblas/stride_model.v`, defining:
  - `strided_from`, a logical view of an array using an explicit starting index and stride;
  - `blas_offset`, modeling GSL’s `OFFSET(N, inc)` calculation; and
  - `blas_strided`, supporting positive, negative, and zero `ddot` strides.
- Adds `strided` to `C/cblas/scal_model.v` for the positive-stride array view used by `dasum` and `dscal`.
- Adds `scal_strided` to model the in-place updates performed by `dscal`, including preservation of unselected elements.
- Adds supporting length, append-step, and array-update lemmas used by the generalized loop invariants.